### PR TITLE
Add support for optional monthStr props

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -90,6 +90,7 @@ const defaultPopperProps = {
 | Name                | Type         | DefaultValue                                 | Description  |
 | ------------------- | ------------ | -------------------------------------------- | ------------ |
 | `dayStr`            | `Array`      | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
+| `monthStr`          | `Array`      | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
 | `multiple`          | `Boolean`    | `false`                                      |  |
 | `type`              | `String`     | `date`                                       | Options: [`year`,`month`,`date`] |
 | `firstDayOfWeek`    | `Number`     | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
@@ -106,6 +107,7 @@ const defaultPopperProps = {
 | Name              | Type                   | DefaultValue                                 | Description  |
 | ----------------- | ---------------------- | -------------------------------------------- | ------------ |
 | `dayStr`          | `Array`                | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
+| `monthStr`        | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
 | `timeStr`         | `Array`                | `['时', '分', '秒']`                          | Used to set time name |
 | `btnStr`          | `String`               | `确定`                                        | Used to set text of button |
 | `firstDayOfWeek`  | `Number`               | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
@@ -116,6 +118,7 @@ const defaultPopperProps = {
 | --------------------- | ---------------------- | -------------------------------------------- | ------------ |
 | `value`               | `Array`                | `[null, null]`                               | Used to set day name |
 | `dayStr`              | `Array`                | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
+| `monthStr`            | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
 | `btnStr`              | `String`               | `确定`                                        | Used to set text of button |
 | `firstDayOfWeek`      | `Number`               | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
 | `secondPlaceholder`   | `String`               | `请选择结束`                                   |  |

--- a/README-CN.md
+++ b/README-CN.md
@@ -90,7 +90,7 @@ const defaultPopperProps = {
 | Name                | Type         | DefaultValue                                 | Description  |
 | ------------------- | ------------ | -------------------------------------------- | ------------ |
 | `dayStr`            | `Array`      | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
-| `monthStr`          | `Array`      | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
+| `monthStr`          | `Array`      | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set month name |
 | `multiple`          | `Boolean`    | `false`                                      |  |
 | `type`              | `String`     | `date`                                       | Options: [`year`,`month`,`date`] |
 | `firstDayOfWeek`    | `Number`     | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
@@ -107,7 +107,7 @@ const defaultPopperProps = {
 | Name              | Type                   | DefaultValue                                 | Description  |
 | ----------------- | ---------------------- | -------------------------------------------- | ------------ |
 | `dayStr`          | `Array`                | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
-| `monthStr`        | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
+| `monthStr`        | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set month name |
 | `timeStr`         | `Array`                | `['时', '分', '秒']`                          | Used to set time name |
 | `btnStr`          | `String`               | `确定`                                        | Used to set text of button |
 | `firstDayOfWeek`  | `Number`               | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
@@ -118,7 +118,7 @@ const defaultPopperProps = {
 | --------------------- | ---------------------- | -------------------------------------------- | ------------ |
 | `value`               | `Array`                | `[null, null]`                               | Used to set day name |
 | `dayStr`              | `Array`                | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
-| `monthStr`            | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
+| `monthStr`            | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set month name |
 | `btnStr`              | `String`               | `确定`                                        | Used to set text of button |
 | `firstDayOfWeek`      | `Number`               | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
 | `secondPlaceholder`   | `String`               | `请选择结束`                                   |  |

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const defaultPopperProps = {
 | Name                | Type         | DefaultValue                                 | Description  |
 | ------------------- | ------------ | -------------------------------------------- | ------------ |
 | `dayStr`            | `Array`      | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
-| `monthStr`          | `Array`      | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
+| `monthStr`          | `Array`      | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set month name |
 | `multiple`          | `Boolean`    | `false`                                      |  |
 | `type`              | `String`     | `date`                                       | Options: [`year`,`month`,`date`] |
 | `firstDayOfWeek`    | `Number`     | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
@@ -114,7 +114,7 @@ const defaultPopperProps = {
 | Name              | Type                   | DefaultValue                                 | Description  |
 | ----------------- | ---------------------- | -------------------------------------------- | ------------ |
 | `dayStr`          | `Array`                | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
-| `monthStr`        | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
+| `monthStr`        | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set month name |
 | `timeStr`         | `Array`                | `['时', '分', '秒']`                          | Used to set time name |
 | `btnStr`          | `String`               | `确定`                                        | Used to set text of button |
 | `firstDayOfWeek`  | `Number`               | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
@@ -125,7 +125,7 @@ const defaultPopperProps = {
 | --------------------- | ---------------------- | -------------------------------------------- | ------------ |
 | `value`               | `Array`                | `[null, null]`                               | Used to set day name |
 | `dayStr`              | `Array`                | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
-| `monthStr`            | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
+| `monthStr`            | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set month name |
 | `btnStr`              | `String`               | `确定`                                        | Used to set text of button |
 | `firstDayOfWeek`      | `Number`               | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
 | `secondPlaceholder`   | `String`               | `请选择结束`                                   |  |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ const defaultPopperProps = {
 | Name                | Type         | DefaultValue                                 | Description  |
 | ------------------- | ------------ | -------------------------------------------- | ------------ |
 | `dayStr`            | `Array`      | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
+| `monthStr`          | `Array`      | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
 | `multiple`          | `Boolean`    | `false`                                      |  |
 | `type`              | `String`     | `date`                                       | Options: [`year`,`month`,`date`] |
 | `firstDayOfWeek`    | `Number`     | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
@@ -113,6 +114,7 @@ const defaultPopperProps = {
 | Name              | Type                   | DefaultValue                                 | Description  |
 | ----------------- | ---------------------- | -------------------------------------------- | ------------ |
 | `dayStr`          | `Array`                | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
+| `monthStr`        | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
 | `timeStr`         | `Array`                | `['时', '分', '秒']`                          | Used to set time name |
 | `btnStr`          | `String`               | `确定`                                        | Used to set text of button |
 | `firstDayOfWeek`  | `Number`               | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
@@ -123,6 +125,7 @@ const defaultPopperProps = {
 | --------------------- | ---------------------- | -------------------------------------------- | ------------ |
 | `value`               | `Array`                | `[null, null]`                               | Used to set day name |
 | `dayStr`              | `Array`                | `['日', '一', '二', '三', '四', '五', '六']`   | Used to set day name |
+| `monthStr`            | `Array`                | `['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']`   | Used to set day name |
 | `btnStr`              | `String`               | `确定`                                        | Used to set text of button |
 | `firstDayOfWeek`      | `Number`               | `0`                                          | Used to set the first day of week. Options: [0, 1, 2, 3, 4, 5, 6] |
 | `secondPlaceholder`   | `String`               | `请选择结束`                                   |  |

--- a/examples/test.html
+++ b/examples/test.html
@@ -36,7 +36,7 @@
   }
   </style>
 </head>
-<body style="padding:100vh 20px; margin: 0">
+<body style="padding:20px; margin: 0">
 <div id="datepicker"></div>
 <div id="daterangepicker"></div>
 <div id="timepicker"></div>
@@ -68,16 +68,18 @@ new Vue({
     ' @input="log"' +
     ' @error="log"' +
     ' min="2018-6-1"' +
-    ' max="2020-01-01"' +
+    ' max="2025-01-01"' +
     // ' type="year"' +
     ' :multiple="true"' +
     ' :dayStr="dayStr"' +
+    ' :monthStr="monthStr"' +
     ' :popperProps="popperProps"' +
     ' :scrollbarProps="{isMobile:isM}"' +
     ' :firstDayOfWeek="1"/>',
   data: function () {
     return {
       dayStr: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      monthStr: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
       date: '',
       isM: isM,
       popperProps: popperProps,
@@ -99,14 +101,16 @@ new Vue({
     ' @input="log"' +
     ' @error="log"' +
     ' min="2018-6-1"' +
-    ' max="2020-01-01"' +
+    ' max="2025-01-01"' +
     ' :dayStr="dayStr"' +
+    ' :monthStr="monthStr"' +
     ' :popperProps="popperProps"' +
     ' :scrollbarProps="{isMobile:isM}"' +
     ' :firstDayOfWeek="1"/>',
   data: function () {
     return {
       dayStr: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      monthStr: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
       date: ['2018-06-01'],
       isM: isM,
       popperProps: popperProps,
@@ -156,7 +160,7 @@ new Vue({
     ' @input="log"' +
     ' @error="log"' +
     ' min="2018-08-24 02:10:02"' +
-    ' max="2020-09-1 22:10:00"' +
+    ' max="2025-09-1 22:10:00"' +
     ' :timeStr="timeStr"' +
     ' :scrollbarProps="{isMobile:isM}"' +
     ' :popperProps="popperProps"/>',

--- a/src/common/Date.vue
+++ b/src/common/Date.vue
@@ -20,7 +20,7 @@
         :key="i + '' + j"
         @click="chose(item)"
         @mouseover="item.canBeChose && $emit('mouseover', item)"
-        >{{ item[type] }}</span
+        >{{ renderItem(type, item[type]) }}</span
       >
     </div>
   </div>
@@ -55,6 +55,7 @@ export default {
     minDate: Object,
     maxDate: Object,
     dayStr: Array,
+    monthStr: Array,
     selectedDates: Array,
     isRange: Boolean,
     firstDayOfWeek: {
@@ -78,6 +79,28 @@ export default {
       return dayStr
         .slice(this.firstDayOfWeek)
         .concat(dayStr.slice(0, this.firstDayOfWeek))
+    },
+    $monthStr() {
+      const monthStr =
+        !this.monthStr ||
+        this.monthStr.length < 12 ||
+        this.monthStr.some(month => typeof month !== 'string')
+          ? [
+              '01',
+              '02',
+              '03',
+              '04',
+              '05',
+              '06',
+              '07',
+              '08',
+              '09',
+              '10',
+              '11',
+              '12',
+            ]
+          : this.monthStr.slice(0, 12)
+      return monthStr
     },
     years() {
       if (!this.dateObj.year) return []
@@ -202,6 +225,12 @@ export default {
         if (this.dateObj.canBeChose)
           this.$emit('to', { type: 'date', ...this.dateObj })
       }
+    },
+    renderItem(type, itemValue) {
+      if (type === 'month') {
+        return this.$monthStr[+itemValue - 1]
+      }
+      return itemValue
     },
   },
 }

--- a/src/common/DatePin.vue
+++ b/src/common/DatePin.vue
@@ -18,7 +18,7 @@
         <template v-if="currType === 'date' || currType === 'time'">
           &nbsp;-&nbsp;
           <span class="month" @click="choseHeadType('month')">{{
-            currDateObj.month
+            renderMonth(currDateObj.month)
           }}</span>
         </template>
         <template v-if="currType === 'time'">
@@ -73,6 +73,7 @@ export default {
     selectedDates: Array,
     isRange: Boolean,
     dayStr: Array,
+    monthStr: Array,
     firstDayOfWeek: Number,
   },
   data() {
@@ -83,6 +84,30 @@ export default {
       currDateObj: {},
       tenYears: '',
     }
+  },
+  computed: {
+    $monthStr() {
+      const monthStr =
+        !this.monthStr ||
+        this.monthStr.length < 12 ||
+        this.monthStr.some(month => typeof month !== 'string')
+          ? [
+              '01',
+              '02',
+              '03',
+              '04',
+              '05',
+              '06',
+              '07',
+              '08',
+              '09',
+              '10',
+              '11',
+              '12',
+            ]
+          : this.monthStr.slice(0, 12)
+      return monthStr
+    },
   },
   watch: {
     type: {
@@ -123,6 +148,9 @@ export default {
       this.currDateObj = item.currObj
       this.tenYears = getTenYears(item.currObj)
       this.$emit('pageChange', item)
+    },
+    renderMonth(monthValue) {
+      return this.$monthStr[+monthValue - 1]
     },
   },
   components: { Date },

--- a/src/common/DatePin.vue
+++ b/src/common/DatePin.vue
@@ -42,6 +42,7 @@
       :minDate="minDate"
       :maxDate="maxDate"
       :dayStr="dayStr"
+      :monthStr="monthStr"
       :firstDayOfWeek="firstDayOfWeek"
       :selectedDates="selectedDates"
       :isRange="isRange"

--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -37,6 +37,7 @@
         :minDate="limit.minDate"
         :maxDate="firstMaxDate"
         :dayStr="dayStr"
+        :monthStr="monthStr"
         :firstDayOfWeek="firstDayOfWeek"
         :isRange="true"
         @itemSelected="chose(0, $event)"
@@ -51,6 +52,7 @@
         :minDate="lastMinDate"
         :maxDate="limit.maxDate"
         :dayStr="dayStr"
+        :monthStr="monthStr"
         :firstDayOfWeek="firstDayOfWeek"
         :isRange="true"
         @itemSelected="chose(1, $event)"
@@ -87,6 +89,7 @@ export default {
     value: Array,
     secondPlaceholder: String,
     dayStr: Array,
+    monthStr: Array,
     firstDayOfWeek: Number,
     rangeSeparator: String,
   },

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -34,6 +34,7 @@
         :minDate="limit.minDate"
         :maxDate="limit.maxDate"
         :dayStr="dayStr"
+        :monthStr="monthStr"
         :firstDayOfWeek="firstDayOfWeek"
         :tenYears="tenYears"
         @itemSelected="chose"
@@ -68,6 +69,7 @@ export default {
     multiple: Boolean,
     type: String,
     dayStr: Array,
+    monthStr: Array,
     firstDayOfWeek: Number,
     btnStr: String,
   },

--- a/src/components/DatetimePicker.vue
+++ b/src/components/DatetimePicker.vue
@@ -33,6 +33,7 @@
         :minDate="limit.minDate"
         :maxDate="limit.maxDate"
         :dayStr="dayStr"
+        :monthStr="monthStr"
         :firstDayOfWeek="firstDayOfWeek"
         @itemSelected="chose"
         @typeChange="typeChange"
@@ -87,6 +88,7 @@ export default {
   name: 'DatetimePicker',
   props: {
     dayStr: Array,
+    monthStr: Array,
     firstDayOfWeek: Number,
     timeStr: Array,
     btnStr: String,


### PR DESCRIPTION
You may pass an array of 12 strings to be used when rendering the month
in the Datepicker, DateRangePicker, or DatetimePicker.

The default is:

    monthStr = ['01', '02', '03', '04', '05', '06',
                '07', '08', '09', '10', '11', '12']